### PR TITLE
DL-14: Update travis' configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 language: java
 
-jdk:
-  - oraclejdk8
+matrix:
+  include:
+    - os: linux
+      jdk: oraclejdk8
+    - os: osx
+      osx_image: xcode8
 
-script: mvn clean test
+cache:
+  directories:
+    - $HOME/.m2
+
+script:
+  - mvn clean verify test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/twitter/distributedlog.svg?branch=master)](https://travis-ci.org/twitter/distributedlog)
+[![Build Status](https://travis-ci.org/apache/incubator-distributedlog.svg?branch=master)](https://travis-ci.org/apache/incubator-distributedlog)
 
 ## Overview
 


### PR DESCRIPTION
Add Apache's license headers, update the link to the correct build, and add instructions to build on OSX.