### PR TITLE
DL-20: Validate bk read timeout in configuration

### DIFF
--- a/distributedlog-core/src/main/java/com/twitter/distributedlog/DistributedLogConfiguration.java
+++ b/distributedlog-core/src/main/java/com/twitter/distributedlog/DistributedLogConfiguration.java
@@ -3336,5 +3336,14 @@ public class DistributedLogConfiguration extends CompositeConfiguration {
         return this;
     }
 
+    /**
+     * Validate the configuration
+     */
+    public void validate() {
+        Preconditions.checkArgument(getBKClientReadTimeout() * 1000 > getReadLACLongPollTimeout(),
+            "Invalid timeout configuration : bkcReadTimeoutSeconds ("+getBKClientReadTimeout()+
+                ") should be longer than readLACLongPollTimeout ("+getReadLACLongPollTimeout()+")");
+    }
+
 
 }

--- a/distributedlog-core/src/main/java/com/twitter/distributedlog/impl/BKDLUtils.java
+++ b/distributedlog-core/src/main/java/com/twitter/distributedlog/impl/BKDLUtils.java
@@ -51,6 +51,8 @@ public class BKDLUtils {
         throws IllegalArgumentException {
         if (null == conf) {
             throw new IllegalArgumentException("Incorrect Configuration");
+        } else {
+            conf.validate();
         }
         if ((null == uri) || (null == uri.getAuthority()) || (null == uri.getPath())) {
             throw new IllegalArgumentException("Incorrect ZK URI");

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestDistributedLogConfiguration.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestDistributedLogConfiguration.java
@@ -102,4 +102,30 @@ public class TestDistributedLogConfiguration {
                 .setEnsemblePlacementDnsResolverClass(TestDNSResolver.class);
         assertEquals(TestDNSResolver.class, conf3.getEnsemblePlacementDnsResolverClass());
     }
+
+    @Test(timeout = 200000)
+    public void validateConfiguration(){
+        boolean exceptionThrown=false;
+        DistributedLogConfiguration conf = new DistributedLogConfiguration();
+        // validate default configuration
+        conf.validate();
+        // test invalid timeout, should throw exception
+        conf.setReadLACLongPollTimeout(conf.getBKClientReadTimeout() * 1000);
+        try {
+            conf.validate();
+        } catch (IllegalArgumentException e){
+            exceptionThrown=true;
+        }
+        assertTrue(exceptionThrown);
+        exceptionThrown=false;
+        conf.setReadLACLongPollTimeout(conf.getBKClientReadTimeout() * 1000 * 2);
+        try {
+            conf.validate();
+        } catch (IllegalArgumentException e){
+            exceptionThrown=true;
+        }
+        assertTrue(exceptionThrown);
+    }
+
+
 }


### PR DESCRIPTION
DL-20: Ensure bkcReadTimeoutSeconds is larger than readLACLongPollTimeout