### PR TITLE
Handle correctly merge commits.

### DIFF
--- a/scripts/dev/dl-merge-pr.py
+++ b/scripts/dev/dl-merge-pr.py
@@ -511,9 +511,11 @@ def main():
 
   # Merged pull requests don't appear as merged in the GitHub API;
   # Instead, they're closed by asfgit.
-  merge_commits = [
-    e for e in pr_events if e['actor']['login'] == 'asfgit' and e['event'] == 'closed'
-  ]
+  merge_commits = []
+  for e in pr_events:
+    if e['event'] == 'closed':
+      if e['actor'] is not None and e['actor']['login'] == 'asfgit':
+        merge_commits.append(e)
 
   if merge_commits:
     merge_hash = merge_commits[0]['commit_id']


### PR DESCRIPTION
In the case of pull request #3, there was a merge commit in the pull
request (https://api.github.com/repos/apache/incubator-distributedlog/commits/2197d49261785a370f22c026cc9fe02f55b7e77c)
which has no login key for the actor, and the script was unable to
handle this situation. Now we check for the presence of the key.