### PR TITLE
 Add infinite retry policy to zookeeper client used by tests

### DIFF
--- a/distributedlog-core/src/main/java/com/twitter/distributedlog/util/RetryPolicyUtils.java
+++ b/distributedlog-core/src/main/java/com/twitter/distributedlog/util/RetryPolicyUtils.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.distributedlog.util;
+
+import org.apache.bookkeeper.zookeeper.BoundExponentialBackoffRetryPolicy;
+import org.apache.bookkeeper.zookeeper.RetryPolicy;
+
+/**
+ * Utils for {@link org.apache.bookkeeper.zookeeper.RetryPolicy}
+ */
+public class RetryPolicyUtils {
+
+    /**
+     * Infinite retry policy
+     */
+    public static final RetryPolicy DEFAULT_INFINITE_RETRY_POLICY = infiniteRetry(200, 2000);
+
+    /**
+     * Create an infinite retry policy with backoff time between <i>baseBackOffTimeMs</i> and
+     * <i>maxBackoffTimeMs</i>.
+     *
+     * @param baseBackoffTimeMs base backoff time in milliseconds
+     * @param maxBackoffTimeMs maximum backoff time in milliseconds
+     * @return an infinite retry policy
+     */
+    public static RetryPolicy infiniteRetry(long baseBackoffTimeMs, long maxBackoffTimeMs) {
+        return new BoundExponentialBackoffRetryPolicy(baseBackoffTimeMs, maxBackoffTimeMs, Integer.MAX_VALUE);
+    }
+
+}

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/DLMTestUtil.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/DLMTestUtil.java
@@ -25,6 +25,7 @@ import com.twitter.distributedlog.namespace.DistributedLogNamespaceBuilder;
 import com.twitter.distributedlog.util.ConfUtils;
 import com.twitter.distributedlog.util.FutureUtils;
 import com.twitter.distributedlog.util.PermitLimiter;
+import com.twitter.distributedlog.util.RetryPolicyUtils;
 import com.twitter.distributedlog.util.Utils;
 import com.twitter.util.Await;
 import com.twitter.util.Duration;
@@ -140,14 +141,9 @@ public class DLMTestUtil {
                                                                int zkPort) throws Exception {
         URI uri = createDLMURI(zkPort, "/" + logName);
 
-        ZooKeeperClientBuilder zkcBuilder = ZooKeeperClientBuilder.newBuilder()
+        ZooKeeperClientBuilder zkcBuilder = TestZooKeeperClientBuilder.newBuilder(conf)
             .name(String.format("dlzk:%s:handler_dedicated", logName))
-            .sessionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
-            .uri(uri)
-            .statsLogger(NullStatsLogger.INSTANCE.scope("dlzk_handler_dedicated"))
-            .retryThreadCount(conf.getZKClientNumberRetryThreads())
-            .requestRateLimit(conf.getZKRequestRateLimit())
-            .zkAclId(conf.getZkAclId());
+            .uri(uri);
 
         ZooKeeperClient zkClient = zkcBuilder.build();
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKDistributedLogManager.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKDistributedLogManager.java
@@ -959,10 +959,8 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
                 new AtomicReference<Collection<LogSegmentMetadata>>();
 
         DistributedLogManager dlm = createNewDLM(conf, name);
-        ZooKeeperClient zkClient = ZooKeeperClientBuilder.newBuilder()
+        ZooKeeperClient zkClient = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createDLMURI("/"))
-                .sessionTimeoutMs(10000)
-                .zkAclId(null)
                 .build();
 
         BKDistributedLogManager.createLog(conf, zkClient, ((BKDistributedLogManager) dlm).uri, name);
@@ -1113,10 +1111,9 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
     public void testTruncationValidation() throws Exception {
         String name = "distrlog-truncation-validation";
         URI uri = createDLMURI("/" + name);
-        ZooKeeperClient zookeeperClient = ZooKeeperClientBuilder.newBuilder()
+        ZooKeeperClient zookeeperClient = TestZooKeeperClientBuilder.newBuilder()
             .uri(uri)
-            .zkAclId(null)
-            .sessionTimeoutMs(10000).build();
+            .build();
         OrderedScheduler scheduler = OrderedScheduler.newBuilder()
                 .name("test-truncation-validation")
                 .corePoolSize(1)

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKDistributedLogNamespace.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKDistributedLogNamespace.java
@@ -67,10 +67,9 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
     @Before
     public void setup() throws Exception {
         zooKeeperClient =
-            ZooKeeperClientBuilder.newBuilder()
+            TestZooKeeperClientBuilder.newBuilder()
                 .uri(createDLMURI("/"))
-                .zkAclId(null)
-                .sessionTimeoutMs(10000).build();
+                .build();
     }
 
     @After
@@ -310,11 +309,9 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
         initDlogMeta(namespace, "test-un", "test-stream");
         URI uri = createDLMURI(namespace);
 
-        ZooKeeperClient zkc = ZooKeeperClientBuilder.newBuilder()
+        ZooKeeperClient zkc = TestZooKeeperClientBuilder.newBuilder()
             .name("unpriv")
             .uri(uri)
-            .sessionTimeoutMs(2000)
-            .zkAclId(null)
             .build();
 
         try {
@@ -340,11 +337,9 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
         initDlogMeta(namespace, "test-un", "test-stream");
         URI uri = createDLMURI(namespace);
 
-        ZooKeeperClient zkc = ZooKeeperClientBuilder.newBuilder()
+        ZooKeeperClient zkc = TestZooKeeperClientBuilder.newBuilder()
             .name("unpriv")
             .uri(uri)
-            .sessionTimeoutMs(2000)
-            .zkAclId(null)
             .build();
 
         zkc.get().getChildren(uri.getPath() + "/test-stream", false, new Stat());

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKLogSegmentWriter.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKLogSegmentWriter.java
@@ -82,16 +82,12 @@ public class TestBKLogSegmentWriter extends TestDistributedLogBase {
         lockStateExecutor = OrderedScheduler.newBuilder().corePoolSize(1).build();
         // build zookeeper client
         URI uri = createDLMURI("");
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder(conf)
                 .name("test-zkc")
-                .sessionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
-                .zkAclId(conf.getZkAclId())
                 .uri(uri)
                 .build();
-        zkc0 = ZooKeeperClientBuilder.newBuilder()
+        zkc0 = TestZooKeeperClientBuilder.newBuilder(conf)
                 .name("test-zkc0")
-                .sessionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
-                .zkAclId(conf.getZkAclId())
                 .uri(uri)
                 .build();
         // build bookkeeper client

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestLedgerHandleCache.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestLedgerHandleCache.java
@@ -43,10 +43,15 @@ public class TestLedgerHandleCache extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
-                .zkServers(zkServers).sessionTimeoutMs(10000).zkAclId(null).build();
-        bkc = BookKeeperClientBuilder.newBuilder().name("bkc")
-                .zkc(zkc).ledgersPath(ledgersPath).dlConfig(conf).build();
+        zkc = TestZooKeeperClientBuilder.newBuilder()
+                .zkServers(zkServers)
+                .build();
+        bkc = BookKeeperClientBuilder.newBuilder()
+                .name("bkc")
+                .zkc(zkc)
+                .ledgersPath(ledgersPath)
+                .dlConfig(conf)
+                .build();
     }
 
     @After
@@ -79,10 +84,16 @@ public class TestLedgerHandleCache extends TestDistributedLogBase {
 
     @Test(timeout = 60000, expected = BKException.ZKException.class)
     public void testOpenLedgerWhenZkClosed() throws Exception {
-        ZooKeeperClient newZkc = ZooKeeperClientBuilder.newBuilder().zkAclId(null).name("zkc-openledger-when-zk-closed")
-                .zkServers(zkServers).sessionTimeoutMs(10000).build();
-        BookKeeperClient newBkc = BookKeeperClientBuilder.newBuilder().name("bkc-openledger-when-zk-closed")
-                .zkc(newZkc).ledgersPath(ledgersPath).dlConfig(conf).build();
+        ZooKeeperClient newZkc = TestZooKeeperClientBuilder.newBuilder()
+                .name("zkc-openledger-when-zk-closed")
+                .zkServers(zkServers)
+                .build();
+        BookKeeperClient newBkc = BookKeeperClientBuilder.newBuilder()
+                .name("bkc-openledger-when-zk-closed")
+                .zkc(newZkc)
+                .ledgersPath(ledgersPath)
+                .dlConfig(conf)
+                .build();
         try {
             LedgerHandle lh = newBkc.get().createLedger(BookKeeper.DigestType.CRC32, "zkcClosed".getBytes(UTF_8));
             lh.close();

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestLogSegmentMetadata.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestLogSegmentMetadata.java
@@ -54,7 +54,9 @@ public class TestLogSegmentMetadata extends ZooKeeperClusterTestCase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder().zkAclId(null).zkServers(zkServers).sessionTimeoutMs(10000).build();
+        zkc = TestZooKeeperClientBuilder.newBuilder()
+                .zkServers(zkServers)
+                .build();
     }
 
     @After

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestNonBlockingReads.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestNonBlockingReads.java
@@ -216,9 +216,7 @@ public class TestNonBlockingReads extends TestDistributedLogBase {
     private long createStreamWithInconsistentMetadata(String name) throws Exception {
         DistributedLogManager dlm = createNewDLM(conf, name);
         ZooKeeperClient zkClient = ZooKeeperClientBuilder.newBuilder()
-                .zkAclId(null)
                 .uri(createDLMURI("/"))
-                .sessionTimeoutMs(10000)
                 .build();
         long txid = 1;
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestNonBlockingReads.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestNonBlockingReads.java
@@ -215,7 +215,7 @@ public class TestNonBlockingReads extends TestDistributedLogBase {
 
     private long createStreamWithInconsistentMetadata(String name) throws Exception {
         DistributedLogManager dlm = createNewDLM(conf, name);
-        ZooKeeperClient zkClient = ZooKeeperClientBuilder.newBuilder()
+        ZooKeeperClient zkClient = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createDLMURI("/"))
                 .build();
         long txid = 1;

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestTruncate.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestTruncate.java
@@ -72,9 +72,8 @@ public class TestTruncate extends TestDistributedLogBase {
         List<LogSegmentMetadata> segments = distributedLogManager.getLogSegments();
         LOG.info("Segments before modifying completion time : {}", segments);
 
-        ZooKeeperClient zkc = ZooKeeperClientBuilder.newBuilder().zkAclId(null).uri(uri)
-                .sessionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
-                .connectionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
+        ZooKeeperClient zkc = TestZooKeeperClientBuilder.newBuilder(conf)
+                .uri(uri)
                 .build();
 
         // Update completion time of first 5 segments
@@ -198,11 +197,8 @@ public class TestTruncate extends TestDistributedLogBase {
         List<LogSegmentMetadata> segments = dlm.getLogSegments();
         LOG.info("Segments before modifying segment status : {}", segments);
 
-        ZooKeeperClient zkc = ZooKeeperClientBuilder.newBuilder()
-                .zkAclId(null)
+        ZooKeeperClient zkc = TestZooKeeperClientBuilder.newBuilder(conf)
                 .uri(uri)
-                .sessionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
-                .connectionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
                 .build();
         setTruncationStatus(zkc, segments.get(0), TruncationStatus.PARTIALLY_TRUNCATED);
         for (int i = 1; i < 4; i++) {
@@ -266,11 +262,8 @@ public class TestTruncate extends TestDistributedLogBase {
         List<LogSegmentMetadata> segments = dlm.getLogSegments();
         LOG.info("Segments before modifying segment status : {}", segments);
 
-        ZooKeeperClient zkc = ZooKeeperClientBuilder.newBuilder()
-                .zkAclId(null)
+        ZooKeeperClient zkc = TestZooKeeperClientBuilder.newBuilder(conf)
                 .uri(uri)
-                .sessionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
-                .connectionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
                 .build();
         for (int i = 0; i < 4; i++) {
             LogSegmentMetadata segment = segments.get(i);

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestZooKeeperClientBuilder.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestZooKeeperClientBuilder.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.distributedlog;
+
+import com.twitter.distributedlog.util.RetryPolicyUtils;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+
+/**
+ * The zookeeper client builder used for testing.
+ */
+public class TestZooKeeperClientBuilder {
+
+    /**
+     * Return a zookeeper client builder for testing.
+     *
+     * @return a zookeeper client builder
+     */
+    public static ZooKeeperClientBuilder newBuilder() {
+        return ZooKeeperClientBuilder.newBuilder()
+                .retryPolicy(RetryPolicyUtils.DEFAULT_INFINITE_RETRY_POLICY)
+                .connectionTimeoutMs(10000)
+                .sessionTimeoutMs(60000)
+                .zkAclId(null)
+                .statsLogger(NullStatsLogger.INSTANCE);
+    }
+
+    /**
+     * Create a zookeeper client builder with provided <i>conf</i> for testing.
+     *
+     * @param conf distributedlog configuration
+     * @return zookeeper client builder
+     */
+    public static ZooKeeperClientBuilder newBuilder(DistributedLogConfiguration conf) {
+        return ZooKeeperClientBuilder.newBuilder()
+                .retryPolicy(RetryPolicyUtils.DEFAULT_INFINITE_RETRY_POLICY)
+                .sessionTimeoutMs(conf.getZKSessionTimeoutMilliseconds())
+                .zkAclId(conf.getZkAclId())
+                .retryThreadCount(conf.getZKClientNumberRetryThreads())
+                .requestRateLimit(conf.getZKRequestRateLimit())
+                .statsLogger(NullStatsLogger.INSTANCE);
+    }
+}

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/acl/TestZKAccessControl.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/acl/TestZKAccessControl.java
@@ -17,8 +17,8 @@
  */
 package com.twitter.distributedlog.acl;
 
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClusterTestCase;
 import com.twitter.distributedlog.thrift.AccessControlEntry;
 import com.twitter.util.Await;
@@ -39,10 +39,9 @@ public class TestZKAccessControl extends ZooKeeperClusterTestCase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createURI("/"))
-                .zkAclId(null)
-                .sessionTimeoutMs(10000).build();
+                .build();
     }
 
     @After

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/acl/TestZKAccessControlManager.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/acl/TestZKAccessControlManager.java
@@ -18,8 +18,8 @@
 package com.twitter.distributedlog.acl;
 
 import com.twitter.distributedlog.DistributedLogConfiguration;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClientUtils;
 import com.twitter.distributedlog.ZooKeeperClusterTestCase;
 import com.twitter.distributedlog.thrift.AccessControlEntry;
@@ -51,10 +51,9 @@ public class TestZKAccessControlManager extends ZooKeeperClusterTestCase {
     @Before
     public void setup() throws Exception {
         executorService = Executors.newSingleThreadScheduledExecutor();
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createURI("/"))
-                .zkAclId(null)
-                .sessionTimeoutMs(10000).build();
+                .build();
         conf = new DistributedLogConfiguration();
     }
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/admin/TestDLCK.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/admin/TestDLCK.java
@@ -24,8 +24,8 @@ import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.DistributedLogManager;
 import com.twitter.distributedlog.LogSegmentMetadata;
 import com.twitter.distributedlog.TestDistributedLogBase;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.metadata.DryrunLogSegmentMetadataStoreUpdater;
 import com.twitter.distributedlog.metadata.LogSegmentMetadataStoreUpdater;
 import com.twitter.distributedlog.util.SchedulerUtils;
@@ -60,11 +60,10 @@ public class TestDLCK extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder
+        zkc = TestZooKeeperClientBuilder
             .newBuilder()
             .uri(createDLMURI("/"))
-            .zkAclId(null)
-            .sessionTimeoutMs(10000).build();
+            .build();
     }
 
     @After

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/admin/TestDistributedLogAdmin.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/admin/TestDistributedLogAdmin.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import com.twitter.distributedlog.DistributedLogConfiguration;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.annotations.DistributedLogAnnotations;
 import com.twitter.distributedlog.util.Utils;
 import org.apache.zookeeper.CreateMode;
@@ -40,7 +41,6 @@ import com.twitter.distributedlog.LogRecord;
 import com.twitter.distributedlog.LogRecordWithDLSN;
 import com.twitter.distributedlog.TestDistributedLogBase;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.metadata.DryrunLogSegmentMetadataStoreUpdater;
 import com.twitter.distributedlog.metadata.LogSegmentMetadataStoreUpdater;
 import com.twitter.util.Await;
@@ -58,11 +58,9 @@ public class TestDistributedLogAdmin extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zooKeeperClient = ZooKeeperClientBuilder
+        zooKeeperClient = TestZooKeeperClientBuilder
             .newBuilder()
             .uri(createDLMURI("/"))
-            .sessionTimeoutMs(10000)
-            .zkAclId(null)
             .build();
         conf.setTraceReadAheadMetadataChanges(true);
     }

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/bk/TestLedgerAllocator.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/bk/TestLedgerAllocator.java
@@ -19,13 +19,13 @@ package com.twitter.distributedlog.bk;
 
 import com.twitter.distributedlog.BookKeeperClient;
 import com.twitter.distributedlog.BookKeeperClientBuilder;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.annotations.DistributedLogAnnotations;
 import com.twitter.distributedlog.bk.SimpleLedgerAllocator.AllocationException;
 import com.twitter.distributedlog.bk.SimpleLedgerAllocator.Phase;
 import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.TestDistributedLogBase;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.exceptions.ZKException;
 import com.twitter.distributedlog.util.FutureUtils;
 import com.twitter.distributedlog.util.Transaction.OpListener;
@@ -94,8 +94,10 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder().uri(createURI("/"))
-                .sessionTimeoutMs(10000).zkAclId(null).zkServers(zkServers).build();
+        zkc = TestZooKeeperClientBuilder.newBuilder()
+                .uri(createURI("/"))
+                .zkServers(zkServers)
+                .build();
         bkc = BookKeeperClientBuilder.newBuilder().name("bkc")
                 .dlConfig(dlConf).ledgersPath(ledgersPath).zkc(zkc).build();
     }

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/bk/TestLedgerAllocatorPool.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/bk/TestLedgerAllocatorPool.java
@@ -22,8 +22,8 @@ import com.twitter.distributedlog.BookKeeperClient;
 import com.twitter.distributedlog.BookKeeperClientBuilder;
 import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.TestDistributedLogBase;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.util.FutureUtils;
 import com.twitter.distributedlog.util.Transaction.OpListener;
 import com.twitter.distributedlog.util.Utils;
@@ -82,8 +82,9 @@ public class TestLedgerAllocatorPool extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder().uri(createURI("/"))
-                .sessionTimeoutMs(10000).zkAclId(null).build();
+        zkc = TestZooKeeperClientBuilder.newBuilder()
+                .uri(createURI("/"))
+                .build();
         bkc = BookKeeperClientBuilder.newBuilder().name("bkc")
                 .dlConfig(dlConf).ledgersPath(ledgersPath).zkc(zkc).build();
         allocationExecutor = Executors.newSingleThreadScheduledExecutor();

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/TestZKLogMetadataStore.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/TestZKLogMetadataStore.java
@@ -21,8 +21,8 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.TestDistributedLogBase;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.util.FutureUtils;
 import com.twitter.distributedlog.util.OrderedScheduler;
 import com.twitter.distributedlog.util.Utils;
@@ -57,9 +57,8 @@ public class TestZKLogMetadataStore extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createDLMURI("/"))
-                .zkAclId(null)
                 .sessionTimeoutMs(zkSessionTimeoutMs)
                 .build();
         scheduler = OrderedScheduler.newBuilder()

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/TestZKLogSegmentMetadataStore.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/TestZKLogSegmentMetadataStore.java
@@ -22,8 +22,8 @@ import com.twitter.distributedlog.DLMTestUtil;
 import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.LogSegmentMetadata;
 import com.twitter.distributedlog.TestDistributedLogBase;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClientUtils;
 import com.twitter.distributedlog.callback.LogSegmentNamesListener;
 import com.twitter.distributedlog.exceptions.ZKException;
@@ -98,9 +98,8 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createDLMURI("/"))
-                .zkAclId(null)
                 .sessionTimeoutMs(zkSessionTimeoutMs)
                 .build();
         scheduler = OrderedScheduler.newBuilder()

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/TestZKNamespaceWatcher.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/TestZKNamespaceWatcher.java
@@ -20,8 +20,8 @@ package com.twitter.distributedlog.impl;
 import com.google.common.collect.Sets;
 import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.TestDistributedLogBase;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClientUtils;
 import com.twitter.distributedlog.callback.NamespaceListener;
 import com.twitter.distributedlog.util.DLUtils;
@@ -60,9 +60,8 @@ public class TestZKNamespaceWatcher extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createDLMURI("/"))
-                .zkAclId(null)
                 .sessionTimeoutMs(zkSessionTimeoutMs)
                 .build();
         scheduler = OrderedScheduler.newBuilder()

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/federated/TestFederatedZKLogMetadataStore.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/federated/TestFederatedZKLogMetadataStore.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.TestDistributedLogBase;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
 import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClientUtils;
@@ -125,9 +126,8 @@ public class TestFederatedZKLogMetadataStore extends TestDistributedLogBase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createDLMURI("/"))
-                .zkAclId(null)
                 .sessionTimeoutMs(zkSessionTimeoutMs)
                 .build();
         scheduler = OrderedScheduler.newBuilder()
@@ -203,9 +203,8 @@ public class TestFederatedZKLogMetadataStore extends TestDistributedLogBase {
     public void testCreateLog() throws Exception {
         DistributedLogConfiguration conf = new DistributedLogConfiguration();
         conf.addConfiguration(baseConf);
-        ZooKeeperClient anotherZkc = ZooKeeperClientBuilder.newBuilder()
+        ZooKeeperClient anotherZkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(uri)
-                .zkAclId(null)
                 .sessionTimeoutMs(zkSessionTimeoutMs)
                 .build();
         FederatedZKLogMetadataStore anotherMetadataStore =
@@ -429,9 +428,8 @@ public class TestFederatedZKLogMetadataStore extends TestDistributedLogBase {
 
         DistributedLogConfiguration anotherConf = new DistributedLogConfiguration();
         anotherConf.addConfiguration(baseConf);
-        ZooKeeperClient anotherZkc = ZooKeeperClientBuilder.newBuilder()
+        ZooKeeperClient anotherZkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(uri)
-                .zkAclId(null)
                 .sessionTimeoutMs(zkSessionTimeoutMs)
                 .build();
         FederatedZKLogMetadataStore anotherMetadataStore =

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/metadata/TestZKLogMetadataForWriter.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/metadata/TestZKLogMetadataForWriter.java
@@ -17,6 +17,7 @@
  */
 package com.twitter.distributedlog.impl.metadata;
 
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.metadata.BKDLConfig;
 import com.twitter.distributedlog.metadata.DLMetadata;
 import com.google.common.collect.Lists;
@@ -92,11 +93,10 @@ public class TestZKLogMetadataForWriter extends ZooKeeperClusterTestCase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .name("zkc")
                 .uri(DLMTestUtil.createDLMURI(zkPort, "/"))
                 .sessionTimeoutMs(sessionTimeoutMs)
-                .zkAclId(null)
                 .build();
     }
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/metadata/TestLogSegmentMetadataStoreUpdater.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/metadata/TestLogSegmentMetadataStoreUpdater.java
@@ -22,6 +22,7 @@ import com.twitter.distributedlog.DLSN;
 import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.LogRecordWithDLSN;
 import com.twitter.distributedlog.LogSegmentMetadata;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
 import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClusterTestCase;
@@ -59,10 +60,10 @@ public class TestLogSegmentMetadataStoreUpdater extends ZooKeeperClusterTestCase
                 .name("test-logsegment-metadata-store-updater")
                 .corePoolSize(1)
                 .build();
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createURI("/"))
-                .zkAclId(null)
-                .sessionTimeoutMs(10000).build();
+                .sessionTimeoutMs(10000)
+                .build();
         metadataStore = new ZKLogSegmentMetadataStore(conf, zkc, scheduler);
     }
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/metadata/TestZkMetadataResolver.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/metadata/TestZkMetadataResolver.java
@@ -19,6 +19,7 @@ package com.twitter.distributedlog.metadata;
 
 import com.twitter.distributedlog.DistributedLogConfiguration;
 import com.twitter.distributedlog.DistributedLogConstants;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.util.Utils;
 import com.twitter.distributedlog.ZooKeeperClient;
 import com.twitter.distributedlog.ZooKeeperClientBuilder;
@@ -47,10 +48,10 @@ public class TestZkMetadataResolver extends ZooKeeperClusterTestCase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .uri(createURI("/"))
-                .zkAclId(null)
-                .sessionTimeoutMs(10000).build();
+                .sessionTimeoutMs(10000)
+                .build();
         resolver = new ZkMetadataResolver(zkc);
     }
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestUtils.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestUtils.java
@@ -19,8 +19,8 @@ package com.twitter.distributedlog.util;
 
 import com.google.common.base.Optional;
 import com.twitter.distributedlog.DLMTestUtil;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.ZooKeeperClusterTestCase;
 import org.apache.bookkeeper.meta.ZkVersion;
 import org.apache.bookkeeper.versioning.Versioned;
@@ -47,11 +47,10 @@ public class TestUtils extends ZooKeeperClusterTestCase {
 
     @Before
     public void setup() throws Exception {
-        zkc = ZooKeeperClientBuilder.newBuilder()
+        zkc = TestZooKeeperClientBuilder.newBuilder()
                 .name("zkc")
                 .uri(DLMTestUtil.createDLMURI(zkPort, "/"))
                 .sessionTimeoutMs(sessionTimeoutMs)
-                .zkAclId(null)
                 .build();
     }
 

--- a/distributedlog-service/src/test/java/com/twitter/distributedlog/service/TestDistributedLogServer.java
+++ b/distributedlog-service/src/test/java/com/twitter/distributedlog/service/TestDistributedLogServer.java
@@ -21,13 +21,13 @@ import com.twitter.distributedlog.AsyncLogReader;
 import com.twitter.distributedlog.DLMTestUtil;
 import com.twitter.distributedlog.DLSN;
 import com.twitter.distributedlog.DistributedLogManager;
+import com.twitter.distributedlog.TestZooKeeperClientBuilder;
 import com.twitter.distributedlog.annotations.DistributedLogAnnotations;
 import com.twitter.distributedlog.exceptions.LogNotFoundException;
 import com.twitter.distributedlog.LogReader;
 import com.twitter.distributedlog.LogRecord;
 import com.twitter.distributedlog.LogRecordWithDLSN;
 import com.twitter.distributedlog.ZooKeeperClient;
-import com.twitter.distributedlog.ZooKeeperClientBuilder;
 import com.twitter.distributedlog.acl.AccessControlManager;
 import com.twitter.distributedlog.acl.ZKAccessControl;
 import com.twitter.distributedlog.client.DistributedLogClientImpl;
@@ -586,12 +586,11 @@ public class TestDistributedLogServer extends DistributedLogServerTestCase {
 
         AccessControlEntry ace = new AccessControlEntry();
         ace.setDenyWrite(true);
-        ZooKeeperClient zkc = ZooKeeperClientBuilder
+        ZooKeeperClient zkc = TestZooKeeperClientBuilder
                 .newBuilder()
                 .uri(getUri())
                 .connectionTimeoutMs(60000)
                 .sessionTimeoutMs(60000)
-                .zkAclId(null)
                 .build();
         DistributedLogNamespace dlNamespace = dlServer.dlServer.getLeft().getDistributedLogNamespace();
         BKDLConfig bkdlConfig = BKDLConfig.resolveDLConfig(zkc, getUri());


### PR DESCRIPTION
This change is to improve the tests running on travis ci