### PR TITLE
Disable travis ci on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ language: java
 
 matrix:
   include:
-    - os: linux
-      jdk: oraclejdk8
     - os: osx
       osx_image: xcode8
 


### PR DESCRIPTION
The travis ci on linux seems to be unstable than on mac, so try to disable travis ci on linux image now.