### PR TITLE
DL-55: Fix the apache-rat check

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "website/_plugins/jekyll-rst"]
-	path = website/_plugins/jekyll-rst
-	url = https://github.com/xdissent/jekyll-rst.git

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
         <configuration>
           <excludes>
             <exclude>docs/**/*</exclude>
+            <exclude>website/**/*</exclude>
             <exclude>.git/**/*</exclude>
             <exclude>.gitignore</exclude>
             <exclude>.idea/**/*</exclude>


### PR DESCRIPTION
- exclude the website directory as well as excluding docs directory
- remove the .gitmodules file (it seems to not be used anyway)