### PR TITLE
DL-126: Fix the url of distributedlog blog post

### DIFF
--- a/website/_posts/2016-09-19-kafka-vs-distributedlog.md
+++ b/website/_posts/2016-09-19-kafka-vs-distributedlog.md
@@ -3,7 +3,8 @@ layout: post
 title:  'A Technical Review of Kafka and DistributedLog'
 date:   2016-09-19 10:00:00
 categories: technical-review
-permalink: /technical-review/2015/09/19/kafka-vs-distributedlog
+redirect_from:
+- /technical-review/2015/09/19/kafka-vs-distributedlog
 authors:
 - sijie
 ---


### PR DESCRIPTION
fix the url for the blog post and but still keep the wrong url and make it redirect to the right url.