### PR TITLE
DL-136: Avoid empty catch blocks

### DIFF
--- a/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/AsyncReaderBenchmark.java
+++ b/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/AsyncReaderBenchmark.java
@@ -44,6 +44,8 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
     @Override
     protected void benchmark(DistributedLogNamespace namespace, String logName, StatsLogger statsLogger) {
         DistributedLogManager dlm = null;
+        Integer zkSessionTimeoutMilliseconds = conf.getZKSessionTimeoutMilliseconds();
+
         while (null == dlm) {
             try {
                 dlm = namespace.openLog(streamName);
@@ -52,8 +54,10 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
             }
             if (null == dlm) {
                 try {
-                    TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
+                    TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
                 } catch (InterruptedException e) {
+                    logger.warn("Failed to create dlm for stream {} after {} ms timeout : ",
+                        new Object[] { streamName, zkSessionTimeoutMilliseconds, e });
                 }
             }
         }
@@ -118,8 +122,10 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
             }
             if (null == reader) {
                 try {
-                    TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
+                    TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
                 } catch (InterruptedException e) {
+                    logger.warn("Failed to create reader for stream {} after {} ms timeout : ",
+                        new Object[] { streamName, zkSessionTimeoutMilliseconds, e });
                 }
                 continue;
             }
@@ -145,8 +151,10 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
                 }
             }
             try {
-                TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
+                TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
             } catch (InterruptedException e) {
+                logger.warn("Reader stream {} interrupted after {} ms timeout : ",
+                    new Object[] { streamName, zkSessionTimeoutMilliseconds, e });
             }
         }
     }

--- a/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/AsyncReaderBenchmark.java
+++ b/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/AsyncReaderBenchmark.java
@@ -44,8 +44,6 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
     @Override
     protected void benchmark(DistributedLogNamespace namespace, String logName, StatsLogger statsLogger) {
         DistributedLogManager dlm = null;
-        Integer zkSessionTimeoutMilliseconds = conf.getZKSessionTimeoutMilliseconds();
-
         while (null == dlm) {
             try {
                 dlm = namespace.openLog(streamName);
@@ -54,7 +52,7 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
             }
             if (null == dlm) {
                 try {
-                    TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
+                    TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
                 } catch (InterruptedException e) {
                     logger.warn("Interrupted from sleep while creating dlm for stream {} : ",
                         streamName, e);
@@ -122,7 +120,7 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
             }
             if (null == reader) {
                 try {
-                    TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
+                    TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
                 } catch (InterruptedException e) {
                     logger.warn("Interrupted from sleep after reader was reassigned null for stream {} : ",
                         streamName, e);
@@ -151,7 +149,7 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
                 }
             }
             try {
-                TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
+                TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
             } catch (InterruptedException e) {
                 logger.warn("Interrupted from sleep while creating reader for stream {} : ",
                     streamName, e);

--- a/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/AsyncReaderBenchmark.java
+++ b/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/AsyncReaderBenchmark.java
@@ -56,8 +56,8 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
                 try {
                     TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
                 } catch (InterruptedException e) {
-                    logger.warn("Failed to create dlm for stream {} after {} ms timeout : ",
-                        new Object[] { streamName, zkSessionTimeoutMilliseconds, e });
+                    logger.warn("Interrupted from sleep while creating dlm for stream {} : ",
+                        streamName, e);
                 }
             }
         }
@@ -124,8 +124,8 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
                 try {
                     TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
                 } catch (InterruptedException e) {
-                    logger.warn("Failed to create reader for stream {} after {} ms timeout : ",
-                        new Object[] { streamName, zkSessionTimeoutMilliseconds, e });
+                    logger.warn("Interrupted from sleep after reader was reassigned null for stream {} : ",
+                        streamName, e);
                 }
                 continue;
             }
@@ -153,8 +153,8 @@ public class AsyncReaderBenchmark extends AbstractReaderBenchmark {
             try {
                 TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
             } catch (InterruptedException e) {
-                logger.warn("Reader stream {} interrupted after {} ms timeout : ",
-                    new Object[] { streamName, zkSessionTimeoutMilliseconds, e });
+                logger.warn("Interrupted from sleep while creating reader for stream {} : ",
+                    streamName, e);
             }
         }
     }

--- a/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/LedgerReadBenchmark.java
+++ b/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/LedgerReadBenchmark.java
@@ -50,8 +50,6 @@ public class LedgerReadBenchmark extends AbstractReaderBenchmark {
     @Override
     protected void benchmark(DistributedLogNamespace namespace, String logName, StatsLogger statsLogger) {
         DistributedLogManager dlm = null;
-        Integer zkSessionTimeoutMilliseconds = conf.getZKSessionTimeoutMilliseconds();
-
         while (null == dlm) {
             try {
                 dlm = namespace.openLog(streamName);
@@ -60,7 +58,7 @@ public class LedgerReadBenchmark extends AbstractReaderBenchmark {
             }
             if (null == dlm) {
                 try {
-                    TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
+                    TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
                 } catch (InterruptedException e) {
                     logger.warn("Interrupted from sleep while creating dlm for stream {} : ",
                         streamName, e);
@@ -78,7 +76,7 @@ public class LedgerReadBenchmark extends AbstractReaderBenchmark {
             }
             if (null == segments) {
                 try {
-                    TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
+                    TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
                 } catch (InterruptedException e) {
                     logger.warn("Interrupted from sleep while geting log segments for stream {} : ",
                         streamName, e);

--- a/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/LedgerReadBenchmark.java
+++ b/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/LedgerReadBenchmark.java
@@ -50,6 +50,8 @@ public class LedgerReadBenchmark extends AbstractReaderBenchmark {
     @Override
     protected void benchmark(DistributedLogNamespace namespace, String logName, StatsLogger statsLogger) {
         DistributedLogManager dlm = null;
+        Integer zkSessionTimeoutMilliseconds = conf.getZKSessionTimeoutMilliseconds();
+
         while (null == dlm) {
             try {
                 dlm = namespace.openLog(streamName);
@@ -58,8 +60,10 @@ public class LedgerReadBenchmark extends AbstractReaderBenchmark {
             }
             if (null == dlm) {
                 try {
-                    TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
+                    TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
                 } catch (InterruptedException e) {
+                    logger.warn("Interrupted from sleep while creating dlm for stream {} : ",
+                        streamName, e);
                 }
             }
         }
@@ -74,8 +78,10 @@ public class LedgerReadBenchmark extends AbstractReaderBenchmark {
             }
             if (null == segments) {
                 try {
-                    TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
+                    TimeUnit.MILLISECONDS.sleep(zkSessionTimeoutMilliseconds);
                 } catch (InterruptedException e) {
+                    logger.warn("Interrupted from sleep while geting log segments for stream {} : ",
+                        streamName, e);
                 }
             }
         }

--- a/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/SyncReaderBenchmark.java
+++ b/distributedlog-benchmark/src/main/java/com/twitter/distributedlog/benchmark/stream/SyncReaderBenchmark.java
@@ -49,6 +49,8 @@ public class SyncReaderBenchmark extends AbstractReaderBenchmark {
                 try {
                     TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
                 } catch (InterruptedException e) {
+                    logger.warn("Interrupted from sleep while creating dlm for stream {} : ",
+                        streamName, e);
                 }
             }
         }
@@ -103,6 +105,8 @@ public class SyncReaderBenchmark extends AbstractReaderBenchmark {
                 try {
                     TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
                 } catch (InterruptedException e) {
+                    logger.warn("Interrupted from sleep after reader was reassigned null for stream {} : ",
+                        streamName, e);
                 }
                 continue;
             }
@@ -140,6 +144,8 @@ public class SyncReaderBenchmark extends AbstractReaderBenchmark {
             try {
                 TimeUnit.MILLISECONDS.sleep(conf.getZKSessionTimeoutMilliseconds());
             } catch (InterruptedException e) {
+                logger.warn("Interrupted from sleep while creating reader for stream {} : ",
+                    streamName, e);
             }
         }
     }

--- a/distributedlog-core/src/main/java/com/twitter/distributedlog/metadata/ZkMetadataResolver.java
+++ b/distributedlog-core/src/main/java/com/twitter/distributedlog/metadata/ZkMetadataResolver.java
@@ -62,6 +62,7 @@ public class ZkMetadataResolver implements MetadataResolver {
             try {
                 return DLMetadata.deserialize(uri, data);
             } catch (IOException ie) {
+                throw new IOException("Failed to deserialize uri : " + uri);
             }
         }
         throw new IOException("No bkdl config bound under dl path : " + dlPath);


### PR DESCRIPTION
* resolves the 9 empty catch blocks in `src/main`
* leaves 49 errors within `src/test` unchanged
  * if we want to resolve those as well let me know, wasn't sure how we wanted to handle that

Used an independent checkstyle that looked for [empty catch blocks](http://checkstyle.sourceforge.net/config_blocks.html#EmptyBlock). Did a quick manual analysis and cannot find any other empty catch blocks in `src/main` so cannot rectify the original 22 as stated in the [Kiuwan blog](https://www.kiuwan.com/blog/analyzing_distributedlog_twitter-2/).