### PR TITLE
DL-123: Every tests should have timeout

### DIFF
--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestInterleavedReaders.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestInterleavedReaders.java
@@ -337,7 +337,7 @@ public class TestInterleavedReaders extends TestDistributedLogBase {
         dlmreader1.close();
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testFactorySharedClients() throws Exception {
         String name = "distrlog-factorysharedclients";
         testFactory(name, true);

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestTruncate.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestTruncate.java
@@ -111,7 +111,7 @@ public class TestTruncate extends TestDistributedLogBase {
         distributedLogManager.close();
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testTruncation() throws Exception {
         String name = "distrlog-truncation";
 
@@ -143,7 +143,7 @@ public class TestTruncate extends TestDistributedLogBase {
         pair.getLeft().close();
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testExplicitTruncation() throws Exception {
         String name = "distrlog-truncation-explicit";
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestWriteLimiter.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestWriteLimiter.java
@@ -43,7 +43,7 @@ public class TestWriteLimiter {
         return new SimplePermitLimiter(darkmode, permits, new NullStatsLogger(), false, feature);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testGlobalOnly() throws Exception {
         SimplePermitLimiter streamLimiter = createPermitLimiter(false, Integer.MAX_VALUE);
         SimplePermitLimiter globalLimiter = createPermitLimiter(false, 1);
@@ -59,7 +59,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 0, globalLimiter, 0);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testStreamOnly() throws Exception {
         SimplePermitLimiter streamLimiter = createPermitLimiter(false, 1);
         SimplePermitLimiter globalLimiter = createPermitLimiter(false, Integer.MAX_VALUE);
@@ -73,7 +73,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 1, globalLimiter, 1);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testDarkmode() throws Exception {
         SimplePermitLimiter streamLimiter = createPermitLimiter(true, Integer.MAX_VALUE);
         SimplePermitLimiter globalLimiter = createPermitLimiter(true, 1);
@@ -83,7 +83,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 2, globalLimiter, 2);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testDarkmodeWithDisabledFeature() throws Exception {
         SettableFeature feature = new SettableFeature("test", 10000);
         SimplePermitLimiter streamLimiter = createPermitLimiter(true, 1, feature);
@@ -97,7 +97,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 0, globalLimiter, 0);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testDisabledFeature() throws Exception {
         // Disable darkmode, but should still ignore limits because of the feature.
         SettableFeature feature = new SettableFeature("test", 10000);
@@ -112,7 +112,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 0, globalLimiter, 0);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testSetDisableFeatureAfterAcquireAndBeforeRelease() throws Exception {
         SettableFeature feature = new SettableFeature("test", 0);
         SimplePermitLimiter streamLimiter = createPermitLimiter(false, 2, feature);
@@ -127,7 +127,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 0, globalLimiter, 0);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testUnsetDisableFeatureAfterPermitsExceeded() throws Exception {
         SettableFeature feature = new SettableFeature("test", 10000);
         SimplePermitLimiter streamLimiter = createPermitLimiter(false, 1, feature);
@@ -153,7 +153,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 0, globalLimiter, 0);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testUnsetDisableFeatureBeforePermitsExceeded() throws Exception {
         SettableFeature feature = new SettableFeature("test", 0);
         SimplePermitLimiter streamLimiter = createPermitLimiter(false, 1, feature);
@@ -171,7 +171,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 2, globalLimiter, 2);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testDarkmodeGlobalUnderStreamOver() throws Exception {
         SimplePermitLimiter streamLimiter = createPermitLimiter(true, 1);
         SimplePermitLimiter globalLimiter = createPermitLimiter(true, 2);
@@ -184,7 +184,7 @@ public class TestWriteLimiter {
         assertPermits(streamLimiter, 0, globalLimiter, 0);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testDarkmodeGlobalOverStreamUnder() throws Exception {
         SimplePermitLimiter streamLimiter = createPermitLimiter(true, 2);
         SimplePermitLimiter globalLimiter = createPermitLimiter(true, 1);

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/bk/TestLedgerAllocatorPool.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/bk/TestLedgerAllocatorPool.java
@@ -258,7 +258,7 @@ public class TestLedgerAllocatorPool extends TestDistributedLogBase {
         assertEquals(numLedgers, allocatedLedgers.size());
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testConcurrentAllocation() throws Exception {
         final int numAllocators = 5;
         String allocationPath = "/concurrentAllocation";

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/config/TestConcurrentBaseConfiguration.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/config/TestConcurrentBaseConfiguration.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
 public class TestConcurrentBaseConfiguration {
     static final Logger LOG = LoggerFactory.getLogger(TestConcurrentBaseConfiguration.class);
 
-    @Test
+    @Test(timeout = 20000)
     public void testBasicOperations() throws Exception {
         ConcurrentBaseConfiguration conf = new ConcurrentBaseConfiguration();
         conf.setProperty("prop1", "1");

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/TestZKLogSegmentFilters.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/impl/TestZKLogSegmentFilters.java
@@ -37,7 +37,7 @@ public class TestZKLogSegmentFilters {
 
     static final Logger LOG = LoggerFactory.getLogger(TestZKLogSegmentFilters.class);
 
-    @Test
+    @Test(timeout = 60000)
     public void testWriteFilter() {
         Set<String> expectedFilteredSegments = new HashSet<String>();
         List<String> segments = new ArrayList<String>();

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/limiter/TestRequestLimiter.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/limiter/TestRequestLimiter.java
@@ -39,7 +39,7 @@ public class TestRequestLimiter {
         }
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testChainedRequestLimiter() throws Exception {
         MockRequestLimiter limiter1 = new MockRequestLimiter();
         MockRequestLimiter limiter2 = new MockRequestLimiter();

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/metadata/TestLogSegmentMetadataStoreUpdater.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/metadata/TestLogSegmentMetadataStoreUpdater.java
@@ -225,7 +225,7 @@ public class TestLogSegmentMetadataStoreUpdater extends ZooKeeperClusterTestCase
         assertEquals(inprogressLogSegment, readInprogressLogSegment);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testChangeTruncationStatus() throws Exception {
         String ledgerPath = "/ledgers2";
         zkc.get().create(ledgerPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestConfUtils.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestConfUtils.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.*;
 
 public class TestConfUtils {
 
-    @Test
+    @Test(timeout = 60000)
     public void testLoadConfiguration() {
         Configuration conf1 = new CompositeConfiguration();
         conf1.setProperty("key1", "value1");

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestPermitManager.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestPermitManager.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.*;
 
 public class TestPermitManager {
 
-    @Test
+    @Test(timeout = 60000)
     public void testUnlimitedPermitManager() {
         PermitManager pm = PermitManager.UNLIMITED_PERMIT_MANAGER;
         List<PermitManager.Permit> permits = new ArrayList<PermitManager.Permit>();
@@ -53,7 +53,7 @@ public class TestPermitManager {
         }
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testLimitedPermitManager() {
         ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
         PermitManager pm = new LimitedPermitManager(1, 0, TimeUnit.SECONDS, executorService);

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestSafeQueueingFuturePool.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestSafeQueueingFuturePool.java
@@ -73,7 +73,7 @@ public class TestSafeQueueingFuturePool {
         }
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testSimpleSuccess() throws Exception {
         TestFuturePool<Void> pool = new TestFuturePool<Void>();
         final AtomicBoolean result = new AtomicBoolean(false);
@@ -88,7 +88,7 @@ public class TestSafeQueueingFuturePool {
         pool.shutdown();
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testSimpleFailure() throws Exception {
         TestFuturePool<Void> pool = new TestFuturePool<Void>();
         Future<Void> future = pool.wrapper.apply(new Function0<Void>() {
@@ -104,7 +104,7 @@ public class TestSafeQueueingFuturePool {
         pool.shutdown();
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testFailedDueToClosed() throws Exception {
         TestFuturePool<Void> pool = new TestFuturePool<Void>();
         pool.wrapper.close();
@@ -121,7 +121,7 @@ public class TestSafeQueueingFuturePool {
         pool.shutdown();
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testRejectedFailure() throws Exception {
         TestFuturePool<Void> pool = new TestFuturePool<Void>();
         final AtomicBoolean result = new AtomicBoolean(false);
@@ -146,7 +146,7 @@ public class TestSafeQueueingFuturePool {
         pool.shutdown();
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testRejectedBackupFailure() throws Exception {
         TestFuturePool<Void> pool = new TestFuturePool<Void>();
         final AtomicBoolean result = new AtomicBoolean(false);

--- a/distributedlog-service/src/test/java/com/twitter/distributedlog/service/stream/TestStreamManager.java
+++ b/distributedlog-service/src/test/java/com/twitter/distributedlog/service/stream/TestStreamManager.java
@@ -100,7 +100,7 @@ public class TestStreamManager {
         assertEquals(0, streamManager.numCached());
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void testCreateStream() throws Exception {
         Stream mockStream = mock(Stream.class);
         final String streamName = "stream1";


### PR DESCRIPTION
* used a simple bash script to find any tests without a timeout

Here is the below bash executed from the root directory. This could be expanded to take in more than one line above the initial `grep` although, for more, it only reduces the false positive rate. After this patch there are only 4 false positives (tests where the text immediately above is not `@Test(timeout = ...)`). 
```
grep -r "public void test" -B 1 * | awk '($NR+1) % 3 !=0 {printf $0; printf " "} NR % 3 == 0 {print " "}' | grep -v "timeout"
```