### PR TITLE
DL-122: Use assertions from Junit rather than assert() for tests

### DIFF
--- a/distributedlog-client/src/test/java/com/twitter/distributedlog/client/routing/TestRoutingService.java
+++ b/distributedlog-client/src/test/java/com/twitter/distributedlog/client/routing/TestRoutingService.java
@@ -17,6 +17,8 @@
  */
 package com.twitter.distributedlog.client.routing;
 
+import static org.junit.Assert.assertEquals;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
@@ -124,7 +126,7 @@ public class TestRoutingService {
             }
         }
 
-        assert(mapping.size() == addresses.size());
+        assertEquals(mapping.size(), addresses.size());
 
         if (null != executorService) {
             executorService.shutdown();

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/DLMTestUtil.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/DLMTestUtil.java
@@ -221,7 +221,7 @@ public class DLMTestUtil {
     public static void verifyLogRecord(LogRecord record) {
         assertEquals(generatePayload(record.getTransactionId()).length, record.getPayload().length);
         assertArrayEquals(generatePayload(record.getTransactionId()), record.getPayload());
-        assert(!record.isControl());
+        assertTrue(!record.isControl());
         verifyPayload(record.getTransactionId(), record.getPayload());
     }
 
@@ -275,7 +275,7 @@ public class DLMTestUtil {
     }
 
     static void verifyEmptyLogRecord(LogRecord record) {
-        assert(record.getPayload().length == 0);
+        assertEquals(record.getPayload().length, 0);
     }
 
     public static LogRecordWithDLSN getLogRecordWithDLSNInstance(DLSN dlsn, long txId) {

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestAsyncReaderWriter.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestAsyncReaderWriter.java
@@ -1108,8 +1108,8 @@ public class TestAsyncReaderWriter extends TestDistributedLogBase {
         writer.abort();
 
         executionTime.stop();
-        assert(!(Thread.interrupted()));
-        assert(success);
+        assertTrue(!(Thread.interrupted()));
+        assertTrue(success);
 
         LogRecordWithDLSN last = dlm.getLastLogRecord();
         LOG.info("Last Entry {}; elapsed time {}", last.getDlsn().getEntryId(), executionTime.elapsed(TimeUnit.MILLISECONDS));
@@ -1546,9 +1546,9 @@ public class TestAsyncReaderWriter extends TestDistributedLogBase {
         } catch (IdleReaderException exc) {
             exceptionEncountered = true;
         }
-        assert(!exceptionEncountered);
+        assertTrue(!exceptionEncountered);
         Assert.assertEquals(recordCount, segmentSize * numSegments);
-        assert(!currentThread.isInterrupted());
+        assertTrue(!currentThread.isInterrupted());
         executor.shutdown();
     }
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKDistributedLogManager.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKDistributedLogManager.java
@@ -725,7 +725,7 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
         LogRecord last = dlm.getLastLogRecord();
         assertEquals(txid - 1, last.getTransactionId());
         DLMTestUtil.verifyLogRecord(last);
-        assert(dlm.isEndOfStreamMarked());
+        assertTrue(dlm.isEndOfStreamMarked());
 
         LogWriter writer = null;
         boolean exceptionEncountered = false;
@@ -738,7 +738,7 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
             exceptionEncountered = true;
         }
         writer.close();
-        assert(exceptionEncountered);
+        assertTrue(exceptionEncountered);
     }
 
     @Test(timeout = 60000)
@@ -805,7 +805,7 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
             FutureUtils.result(out.asyncClose());
         }
         bkdlmAndClients.close();
-        assert(exceptionEncountered);
+        assertTrue(exceptionEncountered);
     }
 
     @Test(timeout = 60000)
@@ -831,7 +831,7 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
             FutureUtils.result(out.asyncClose());
         }
         bkdlmAndClients.close();
-        assert(!exceptionEncountered);
+        assertTrue(!exceptionEncountered);
     }
 
     @Test(timeout = 60000)
@@ -884,7 +884,7 @@ public class TestBKDistributedLogManager extends TestDistributedLogBase {
         } catch (LogNotFoundException exc) {
             exceptionEncountered = true;
         }
-        assert(exceptionEncountered);
+        assertTrue(exceptionEncountered);
         reader.close();
     }
 

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKDistributedLogNamespace.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestBKDistributedLogNamespace.java
@@ -49,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.*;
 
 public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
@@ -122,10 +123,10 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
             BKDistributedLogManager bkdlm2 = (BKDistributedLogManager)namespace.createDistributedLogManager("perstream2",
                 DistributedLogManagerFactory.ClientSharingOption.PerStreamClients);
 
-            assert(bkdlm1.getReaderBKC() != bkdlm2.getReaderBKC());
-            assert(bkdlm1.getWriterBKC() != bkdlm2.getWriterBKC());
-            assert(bkdlm1.getReaderZKC() != bkdlm2.getReaderZKC());
-            assert(bkdlm1.getWriterZKC() != bkdlm2.getWriterZKC());
+            assertThat(bkdlm1.getReaderBKC(), not(bkdlm2.getReaderBKC()));
+            assertThat(bkdlm1.getWriterBKC(), not(bkdlm2.getWriterBKC()));
+            assertThat(bkdlm1.getReaderZKC(), not(bkdlm2.getReaderZKC()));
+            assertThat(bkdlm1.getWriterZKC(), not(bkdlm2.getWriterZKC()));
 
         }
 
@@ -136,10 +137,10 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
             BKDistributedLogManager bkdlm2 = (BKDistributedLogManager)namespace.createDistributedLogManager("sharedZK2",
                 DistributedLogManagerFactory.ClientSharingOption.SharedZKClientPerStreamBKClient);
 
-            assert(bkdlm1.getReaderBKC() != bkdlm2.getReaderBKC());
-            assert(bkdlm1.getWriterBKC() != bkdlm2.getWriterBKC());
-            assert(bkdlm1.getReaderZKC() == bkdlm2.getReaderZKC());
-            assert(bkdlm1.getWriterZKC() == bkdlm2.getWriterZKC());
+            assertThat(bkdlm1.getReaderBKC(), not(bkdlm2.getReaderBKC()));
+            assertThat(bkdlm1.getWriterBKC(), not(bkdlm2.getWriterBKC()));
+            assertEquals(bkdlm1.getReaderZKC(), bkdlm2.getReaderZKC());
+            assertEquals(bkdlm1.getWriterZKC(), bkdlm2.getWriterZKC());
         }
 
         {
@@ -149,10 +150,10 @@ public class TestBKDistributedLogNamespace extends TestDistributedLogBase {
             BKDistributedLogManager bkdlm2 = (BKDistributedLogManager)namespace.createDistributedLogManager("sharedBoth2",
                 DistributedLogManagerFactory.ClientSharingOption.SharedClients);
 
-            assert(bkdlm1.getReaderBKC() == bkdlm2.getReaderBKC());
-            assert(bkdlm1.getWriterBKC() == bkdlm2.getWriterBKC());
-            assert(bkdlm1.getReaderZKC() == bkdlm2.getReaderZKC());
-            assert(bkdlm1.getWriterZKC() == bkdlm2.getWriterZKC());
+            assertEquals(bkdlm1.getReaderBKC(), bkdlm2.getReaderBKC());
+            assertEquals(bkdlm1.getWriterBKC(), bkdlm2.getWriterBKC());
+            assertEquals(bkdlm1.getReaderZKC(), bkdlm2.getReaderZKC());
+            assertEquals(bkdlm1.getWriterZKC(), bkdlm2.getWriterZKC());
         }
 
     }

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/TestDistributedLogBase.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/TestDistributedLogBase.java
@@ -17,6 +17,8 @@
  */
 package com.twitter.distributedlog;
 
+import static org.junit.Assert.assertTrue;
+
 import com.twitter.distributedlog.impl.BKLogSegmentEntryWriter;
 import com.twitter.distributedlog.logsegment.LogSegmentEntryWriter;
 import com.twitter.distributedlog.logsegment.LogSegmentMetadataStore;
@@ -188,27 +190,27 @@ public class TestDistributedLogBase {
     @SuppressWarnings("deprecation")
     protected LogSegmentMetadataStore getLogSegmentMetadataStore(DistributedLogManagerFactory factory) {
         DistributedLogNamespace namespace = factory.getNamespace();
-        assert(namespace instanceof BKDistributedLogNamespace);
+        assertTrue(namespace instanceof BKDistributedLogNamespace);
         return ((BKDistributedLogNamespace) namespace).getWriterSegmentMetadataStore();
     }
 
     @SuppressWarnings("deprecation")
     protected ZooKeeperClient getZooKeeperClient(DistributedLogManagerFactory factory) throws Exception {
         DistributedLogNamespace namespace = factory.getNamespace();
-        assert(namespace instanceof BKDistributedLogNamespace);
+        assertTrue(namespace instanceof BKDistributedLogNamespace);
         return ((BKDistributedLogNamespace) namespace).getSharedWriterZKCForDL();
     }
 
     @SuppressWarnings("deprecation")
     protected BookKeeperClient getBookKeeperClient(DistributedLogManagerFactory factory) throws Exception {
         DistributedLogNamespace namespace = factory.getNamespace();
-        assert(namespace instanceof BKDistributedLogNamespace);
+        assertTrue(namespace instanceof BKDistributedLogNamespace);
         return ((BKDistributedLogNamespace) namespace).getReaderBKC();
     }
 
     protected LedgerHandle getLedgerHandle(BKLogSegmentWriter segmentWriter) {
         LogSegmentEntryWriter entryWriter = segmentWriter.getEntryWriter();
-        assert(entryWriter instanceof BKLogSegmentEntryWriter);
+        assertTrue(entryWriter instanceof BKLogSegmentEntryWriter);
         return ((BKLogSegmentEntryWriter) entryWriter).getLedgerHandle();
     }
 }


### PR DESCRIPTION
* changed all instances of `assert()` to junit versions in `src/test`

Here is the script I used to find all instances of `assert()` inside the `src/test` folder:

```
grep -r "assert(" * 2>/dev/null | grep -v "main"
```

The `grep -v "main"` removes all instances of the usage within the main source tree (which there are quite a few). I did this as I assumed the JIRA ticket spirit was not to remove those instances from the main tree and thus would require including `junit` in core compilation rather than scoped for `test` as is.