### PR TITLE
DL-145 : the write requests should be error out immediately even if the rolling writer still be creating

### DIFF
--- a/distributedlog-core/src/main/java/com/twitter/distributedlog/BKAsyncLogWriter.java
+++ b/distributedlog-core/src/main/java/com/twitter/distributedlog/BKAsyncLogWriter.java
@@ -521,6 +521,7 @@ public class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWri
 
     @Override
     public Future<Void> asyncAbort() {
+        Future<Void> result = super.asyncAbort();
         synchronized (this) {
             if (pendingRequests != null) {
                 for (PendingLogRecord pendingLogRecord : pendingRequests) {
@@ -529,7 +530,7 @@ public class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWri
                 }
             }
         }
-        return super.asyncAbort();
+        return result;
     }
 
     @Override

--- a/distributedlog-core/src/main/java/com/twitter/distributedlog/BKAsyncLogWriter.java
+++ b/distributedlog-core/src/main/java/com/twitter/distributedlog/BKAsyncLogWriter.java
@@ -520,6 +520,19 @@ public class BKAsyncLogWriter extends BKAbstractLogWriter implements AsyncLogWri
     }
 
     @Override
+    public Future<Void> asyncAbort() {
+        synchronized (this) {
+            if (pendingRequests != null) {
+                for (PendingLogRecord pendingLogRecord : pendingRequests) {
+                    pendingLogRecord.promise.setException(new WriteException(bkDistributedLogManager.getStreamName(),
+                            "abort wring: writer has been closed due to error."));
+                }
+            }
+        }
+        return super.asyncAbort();
+    }
+
+    @Override
     public String toString() {
         return String.format("AsyncLogWriter:%s", getStreamName());
     }


### PR DESCRIPTION
Passed all test cases locally, now TestDistributedLogService#testServiceTimeout case is stable on my box