### PR TITLE
DL-171 : adding a short sleep to let the WriteCompleteListener have time to run before the final position be requested

### DIFF
--- a/distributedlog-core/src/test/java/org/apache/distributedlog/TestAppendOnlyStreamWriter.java
+++ b/distributedlog-core/src/test/java/org/apache/distributedlog/TestAppendOnlyStreamWriter.java
@@ -189,6 +189,7 @@ public class TestAppendOnlyStreamWriter extends TestDistributedLogBase {
         assertEquals(0, writer.position());
 
         Await.result(writer.write(byteStream));
+        Thread.sleep(100); // let WriteCompleteListener have time to run
         assertEquals(33, writer.position());
 
         writer.close();


### PR DESCRIPTION
once the "writer.write" is done, if "writer.position()" be invoked easier than the WriteCompleteListener onSuccess callback, due to the "synchronized", the position result will be 0, not the expected 33. we can just add a short sleep to avoid this test issue.