### PR TITLE
DL-174: added getParent method to Utils to replace usage of File.getParent which changes / to \ on Windows

### DIFF
--- a/distributedlog-core/src/main/java/com/twitter/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
+++ b/distributedlog-core/src/main/java/com/twitter/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
@@ -335,7 +335,7 @@ public class ZKLogStreamMetadataStore implements LogStreamMetadataStore {
         // Note re. persistent lock state initialization: the read lock persistent state (path) is
         // initialized here but only used in the read handler. The reason is its more convenient and
         // less error prone to manage all stream structure in one place.
-        final String logRootParentPath = new File(logRootPath).getParent();
+        final String logRootParentPath = Utils.getParent(logRootPath);
         final String logSegmentsPath = logRootPath + LOGSEGMENTS_PATH;
         final String maxTxIdPath = logRootPath + MAX_TXID_PATH;
         final String lockPath = logRootPath + LOCK_PATH;
@@ -383,7 +383,7 @@ public class ZKLogStreamMetadataStore implements LogStreamMetadataStore {
         if (pathExists(metadatas.get(MetadataIndex.LOG_ROOT_PARENT))) {
             pathsToCreate.add(null);
         } else {
-            String logRootParentPath = new File(logRootPath).getParent();
+            String logRootParentPath = Utils.getParent(logRootPath);
             pathsToCreate.add(DistributedLogConstants.EMPTY_BYTES);
             zkOps.add(Op.create(logRootParentPath, DistributedLogConstants.EMPTY_BYTES, acl, createMode));
         }

--- a/distributedlog-core/src/main/java/com/twitter/distributedlog/util/Utils.java
+++ b/distributedlog-core/src/main/java/com/twitter/distributedlog/util/Utils.java
@@ -604,4 +604,35 @@ public class Utils {
                 executorService).map(VoidFunctions.LIST_TO_VOID_FUNC);
     }
 
+    /**
+     * Gets the parent of a path.
+     *
+     * @param path
+     *            path to get the parent of
+     * @return parent of the path or null if no parent exists.
+     */
+    public static String getParent(final String path) {
+        if (path == null) {
+            return null;
+        }
+        if (path.length() < 2) {
+            return null;
+        }
+        int firstIndex = path.indexOf("/");
+        if (firstIndex == -1) {
+            return null;
+        }
+        int lastIndex = path.lastIndexOf("/");
+        if (lastIndex == path.length() - 1) {
+            lastIndex = path.substring(0, path.length() - 1).lastIndexOf("/");
+        }
+        if (lastIndex == -1) {
+            return null;
+        }
+        if (lastIndex == 0) {
+            return "/";
+        }
+        return path.substring(0, lastIndex);
+    }
+
 }

--- a/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestUtils.java
+++ b/distributedlog-core/src/test/java/com/twitter/distributedlog/util/TestUtils.java
@@ -122,4 +122,32 @@ public class TestUtils extends ZooKeeperClusterTestCase {
         assertEquals("Version should be zero",
                 0, ((ZkVersion) data.getVersion()).getZnodeVersion());
     }
+
+    @Test(timeout = 60000)
+    public void testGetParent() throws Exception {
+        String path1 = null;
+        assertNull("parent of a null path is null", Utils.getParent(path1));
+
+        String path2 = "";
+        assertNull("parent of an empty string is null", Utils.getParent(path2));
+
+        String path3 = "abcdef";
+        assertNull("parent of a string with no / is null", Utils.getParent(path3));
+
+        String path4 = "/test/test2";
+        assertEquals("parent of a /test/test2 is /test", "/test", Utils.getParent(path4));
+
+        String path5 = "/test/test2/";
+        assertEquals("parent of a " + path5 + " is /test", "/test", Utils.getParent(path5));
+
+        String path6 = "/test";
+        assertEquals("parent of " + path6 + " is /", "/", Utils.getParent(path6));
+
+        String path7 = "//";
+        assertEquals("parent of " + path7 + " is /", "/", Utils.getParent(path7));
+
+        String path8 = "/";
+        assertNull("parent of " + path8 + " is null", Utils.getParent(path8));
+    }
+
 }


### PR DESCRIPTION
…ich changes / to \ in Windows.